### PR TITLE
feat: Add /scripture reload command

### DIFF
--- a/src/main/java/org/scripture/scripture/Scripture.java
+++ b/src/main/java/org/scripture/scripture/Scripture.java
@@ -1,6 +1,7 @@
 package org.scripture.scripture;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.scripture.scripture.command.ScriptureReloadCommand; // Import the new command class
 import org.scripture.scripture.util.GuiUtils;
 
 public final class Scripture extends JavaPlugin {
@@ -9,6 +10,12 @@ public final class Scripture extends JavaPlugin {
     public void onEnable() {
         // Log startup
         getLogger().info("Scripture plugin is starting up!");
+        // Save the default config.yml from the JAR to the plugin's data folder if it doesn't already exist.
+        // This ensures that a default configuration is always available.
+        saveDefaultConfig();
+        // Load the configuration from config.yml. This includes any user-defined values or defaults.
+        // This method is also responsible for initializing any components that depend on the configuration.
+        loadPluginConfig(); // Initial load of configuration
 
         // Register command using Paper's recommended approach
         BookTestCommand bookTestCommand = new BookTestCommand(this);
@@ -17,31 +24,55 @@ public final class Scripture extends JavaPlugin {
         org.bukkit.command.CommandMap commandMap = getServer().getCommandMap();
 
         // Create a PluginCommand using reflection (since constructor is protected)
-        org.bukkit.command.PluginCommand pluginCommand;
+        org.bukkit.command.PluginCommand bookTestPluginCommand; // Renamed for clarity
         try {
             java.lang.reflect.Constructor<org.bukkit.command.PluginCommand> constructor =
                     org.bukkit.command.PluginCommand.class.getDeclaredConstructor(String.class, org.bukkit.plugin.Plugin.class);
             constructor.setAccessible(true);
-            pluginCommand = constructor.newInstance("booktest", this);
+            bookTestPluginCommand = constructor.newInstance("booktest", this); // Command name "booktest"
 
-            // Set command properties
-            pluginCommand.setDescription("Open the Paper to Coin GUI");
-            pluginCommand.setUsage("/<command>");
-            pluginCommand.setPermission("booktest.use");
-            pluginCommand.setPermissionMessage(GuiUtils.colorize("&cYou don't have permission to use this command!"));
+            // Set command properties for booktest
+            bookTestPluginCommand.setDescription("Open the Paper to Coin GUI");
+            bookTestPluginCommand.setUsage("/<command>"); // Generic usage, specific usage in plugin.yml for subcommands
+            bookTestPluginCommand.setPermission("booktest.use");
+            bookTestPluginCommand.setPermissionMessage(GuiUtils.colorize("&cYou don't have permission to use this command!"));
 
-            // Set the executor and tab completer
-            pluginCommand.setExecutor(bookTestCommand);
-            pluginCommand.setTabCompleter(bookTestCommand);
+            // Set the executor and tab completer for booktest
+            bookTestPluginCommand.setExecutor(bookTestCommand);
+            bookTestPluginCommand.setTabCompleter(bookTestCommand);
 
-            // Register the command
-            commandMap.register("scripture", pluginCommand);
+            // Register the booktest command
+            commandMap.register("scripture", bookTestPluginCommand); // Keep "scripture" as prefix for this command for now
 
             getLogger().info("Successfully registered the booktest command!");
         } catch (Exception e) {
             getLogger().severe("Failed to register the booktest command: " + e.getMessage());
             e.printStackTrace();
         }
+
+        // Register the /scripture command (which includes /scripture reload)
+        // This command is defined in plugin.yml, so we retrieve it and set its executor.
+        try {
+            // The command 'scripture' (handling subcommands like 'reload') is defined in plugin.yml.
+            // We use getCommand() to retrieve it from Bukkit's command system.
+            org.bukkit.command.PluginCommand scriptureMainCommand = getCommand("scripture");
+            if (scriptureMainCommand != null) {
+                // Set the executor for the /scripture command to our ScriptureReloadCommand class.
+                // This class will handle the logic for subcommands like /scripture reload.
+                scriptureMainCommand.setExecutor(new ScriptureReloadCommand(this));
+                // A TabCompleter could be added here if more subcommands are introduced later,
+                // to provide suggestions for subcommands.
+                // e.g., scriptureMainCommand.setTabCompleter(new ScriptureTabCompleter());
+                getLogger().info("Successfully registered the main /scripture command executor!");
+            } else {
+                // This error indicates a mismatch between plugin.yml and the code, or an issue with Bukkit's command registration.
+                getLogger().severe("Failed to get the '/scripture' command. Ensure it is defined in plugin.yml.");
+            }
+        } catch (Exception e) {
+            getLogger().severe("Failed to register the /scripture command executor: " + e.getMessage());
+            e.printStackTrace();
+        }
+
 
         // Register inventory listener
         getServer().getPluginManager().registerEvents(new BookGuiListener(this), this);
@@ -52,5 +83,53 @@ public final class Scripture extends JavaPlugin {
     @Override
     public void onDisable() {
         getLogger().info("Scripture plugin has been disabled.");
+    }
+
+    /**
+     * Reloads the plugin's configuration.
+     * This method is typically called by a command (e.g., /scripture reload).
+     * It ensures that changes made to the config.yml on disk are loaded into the plugin
+     * and that relevant parts of the plugin are re-initialized with the new configuration.
+     */
+    public void reloadPluginConfig() {
+        // Optional: Add logic here to safely disable or reset components before reloading.
+        // For example, if listeners or tasks depend heavily on config values, they might
+        // need to be unregistered or cancelled before loadPluginConfig() is called.
+        getLogger().info("Reloading Scripture plugin configuration...");
+
+        loadPluginConfig(); // The core logic for loading/reloading configuration
+
+        // Optional: Add logic here to re-enable or re-initialize components based on the new config.
+        // For example, re-register listeners or reschedule tasks if they were affected by the reload.
+        getLogger().info("Scripture plugin configuration reloaded successfully.");
+    }
+
+    /**
+     * Loads or reloads the plugin's configuration from the config.yml file.
+     * This method handles reading the configuration values and should also
+     * be responsible for applying these settings, such as re-initializing
+     * any internal caches, settings, or components that depend on the configuration.
+     * This method is called during onEnable for initial setup and by reloadPluginConfig()
+     * for runtime reloading.
+     */
+    private void loadPluginConfig() {
+        // This Bukkit method reloads the config.yml from disk, updating the plugin's internal
+        // FileConfiguration object. If the file has changed, new values are loaded.
+        // If the file doesn't exist (e.g., on first run after saveDefaultConfig()),
+        // it loads the defaults that were just saved.
+        this.reloadConfig();
+
+        getLogger().info("Configuration loaded/reloaded from disk.");
+
+        // Placeholder for logic to apply loaded configuration values.
+        // This is where you would typically:
+        // - Read values using this.getConfig().getString(), .getInt(), .getBoolean(), etc.
+        // - Update internal variables or re-initialize classes that depend on these values.
+        // - For example:
+        //   String welcomeMessage = this.getConfig().getString("messages.welcome", "Welcome!");
+        //   GuiUtils.loadColorsFromConfig(this.getConfig()); // If GuiUtils needs config values
+        //   int someSetting = this.getConfig().getInt("some.setting", defaultValue);
+        //   this.someInternalComponent.updateSettings(this.getConfig());
+        getLogger().info("Applying configuration to plugin components (if any).");
     }
 }

--- a/src/main/java/org/scripture/scripture/command/ScriptureReloadCommand.java
+++ b/src/main/java/org/scripture/scripture/command/ScriptureReloadCommand.java
@@ -1,0 +1,48 @@
+package org.scripture.scripture.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.scripture.scripture.Scripture; // Import the main plugin class
+
+/**
+ * Handles the `/scripture reload` command, allowing administrators
+ * to reload the plugin's configuration without restarting the server.
+ */
+public class ScriptureReloadCommand implements CommandExecutor {
+
+    private final Scripture plugin;
+
+    /**
+     * Constructs the ScriptureReloadCommand.
+     * @param plugin An instance of the main Scripture plugin class, used to access plugin functionalities like config reloading.
+     */
+    public ScriptureReloadCommand(Scripture plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (args.length > 0 && args[0].equalsIgnoreCase("reload")) {
+            if (!sender.hasPermission("scripture.reload")) {
+                sender.sendMessage(org.bukkit.ChatColor.RED + "You do not have permission to reload the Scripture plugin.");
+                return true;
+            }
+
+            try {
+                plugin.reloadPluginConfig(); // Calls the method in the main plugin class to perform the reload.
+                sender.sendMessage(org.bukkit.ChatColor.GREEN + "Scripture plugin configuration reloaded successfully.");
+            } catch (Exception e) {
+                sender.sendMessage(org.bukkit.ChatColor.RED + "Failed to reload Scripture plugin configuration. Check console for errors.");
+                plugin.getLogger().severe("Error during plugin reload: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return true;
+        }
+        // If not the 'reload' subcommand, or no subcommand is provided.
+        // Returning false will show the usage message from plugin.yml if defined for the base command.
+        return false;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,22 @@ version: '1.0-SNAPSHOT'
 main: org.scripture.scripture.Scripture
 api-version: '1.21'
 authors: [ serenesummwr ]
+commands:
+  scripture:
+    description: Main command for the Scripture plugin.
+    aliases: [scr]
+    permission: scripture.use # Base permission for /scripture if other subcommands are added later
+    permission-message: You do not have permission to use this command.
+    subcommands:
+      reload:
+        description: Reloads the Scripture plugin's configuration.
+        usage: /scripture reload
+        permission: scripture.reload
+        permission-message: You do not have permission to reload the plugin.
+permissions:
+  scripture.use: # Optional: if you want a base permission for /scripture itself
+    description: Allows access to base Scripture commands.
+    default: true
+  scripture.reload:
+    description: Allows reloading the Scripture plugin.
+    default: op


### PR DESCRIPTION
Adds a `/scripture reload` command to allow reloading the plugin's configuration without a full server restart.

Key changes:
- Defined the command `scripture` with subcommand `reload` in `plugin.yml`.
- Added permission `scripture.reload` (default: op) for the command.
- Created `ScriptureReloadCommand.java` to handle command logic, permission checking, and user feedback.
- Implemented `reloadPluginConfig()` and `loadPluginConfig()` methods in the main `Scripture.java` class, utilizing `reloadConfig()` and `saveDefaultConfig()`.
- Registered the new command executor in `onEnable`.
- Added Javadoc and inline comments for maintainability.

The reload mechanism now calls `reloadConfig()` and is structured to allow for future expansion of re-initializing other plugin components that might depend on the configuration.